### PR TITLE
Fix input error when using thousands and decimals

### DIFF
--- a/packages/frontend/src/components/DollarInput/index.tsx
+++ b/packages/frontend/src/components/DollarInput/index.tsx
@@ -78,7 +78,7 @@ export default function DollarInput({
         value={amount}
         {...rest}
         type="text"
-        pattern="[0-9]+([\.,][0-9]+)?"
+        pattern="[0-9]+([\.,][0-9]+){0,2}"
         style={{ width: length, padding: 0 }}
         placeholder="0"
         className={cls(


### PR DESCRIPTION
This fixes an error which occurs when entered number is more than thousand and contains decimals.

## Error without change in pattern
<details>
<summary>Image</summary>
<img width="380" alt="image" src="https://user-images.githubusercontent.com/42418433/186429271-9bbe66ab-d0e4-43da-9a47-0be870c4b62b.png">
</details>

## Solution tested in 

- Chrome
- Safari




